### PR TITLE
Add automatic builds for g++-4.8 up to g++-8 and clang++-4.0 to clang…

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,43 @@
+# Although this is a C++ project, we use different PHP versions
+language: php
+
+# we need bionic
+dist: trusty
+sudo: required
+group: edge
+
+php:
+  - 7.0
+  - 7.1
+  - 7.2
+#  - nightly # doesn't work yet on PHP 7.3! not building.
+
+
+# setting the env is the easiest, because it will mix with all the separate php versions (travis does this)
+env:
+  - COMPILER_PKG=g++-4.8 COMPILER=g++-4.8
+  - COMPILER_PKG=g++-4.9 COMPILER=g++-4.9
+  - COMPILER_PKG=g++-5 COMPILER=g++-5
+  - COMPILER_PKG=g++-6 COMPILER=g++-6
+  - COMPILER_PKG=g++-7 COMPILER=g++-7
+  - COMPILER_PKG=g++-8 COMPILER=g++-8
+  - COMPILER_PKG=clang++-4 COMPILER=clang++-4.0
+  - COMPILER_PKG=clang++-5 COMPILER=clang++-5.0
+  - COMPILER_PKG=clang++-6 COMPILER=clang++-6.0
+
+before_install:
+  # install access to all gcc compilers
+  - sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
+
+  # and all relevant clang compilers
+  - sudo apt-add-repository "deb http://apt.llvm.org/trusty/ llvm-toolchain-trusty-4.0 main"
+  - sudo apt-add-repository "deb http://apt.llvm.org/trusty/ llvm-toolchain-trusty-5.0 main"
+  - sudo apt-add-repository "deb http://apt.llvm.org/trusty/ llvm-toolchain-trusty-6.0 main"
+
+  # update package index and install correct compiler
+  - sudo apt-get -y update
+  - sudo apt-get -y --allow-unauthenticated --no-install-recommends install ${COMPILER_PKG}
+
+script:
+  # simply make the project with the set compiler
+  - make -j4 COMPILER=$COMPILER && sudo make install

--- a/Makefile
+++ b/Makefile
@@ -117,7 +117,7 @@ PHP_COMPILER_FLAGS		=	${COMPILER_FLAGS} `${PHP_CONFIG} --includes`
 #
 
 LINKER_FLAGS			=	-shared
-PHP_LINKER_FLAGS		=	${LINKER_FLAGS} `${PHP_CONFIG} --ldflags`
+PHP_LINKER_FLAGS		=	`${PHP_CONFIG} --ldflags` ${LINKER_FLAGS}
 
 
 #

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 PHP-CPP
 =======
 
+[![Build Status](https://travis-ci.org/CopernicaMarketingSoftware/PHP-CPP.svg?branch=master)](https://travis-ci.org/CopernicaMarketingSoftware/PHP-CPP)
+
 The PHP-CPP library is a C++ library for developing PHP extensions. It offers a collection
 of well documented and easy-to-use classes that can be used and extended to build native
 extensions for PHP. The full documentation can be found on http://www.php-cpp.com.


### PR DESCRIPTION
…++-6.0. Also resolves #357 by moving the `-shared` flag further down on the command line parameters, after the point PHP had the chance to taint them by including the `-pie` flag.